### PR TITLE
Fix mangled worker stdout/stderr

### DIFF
--- a/R/engine.R
+++ b/R/engine.R
@@ -131,14 +131,14 @@ drain_runner_log <- function(engine) {
     if (nzchar(data)) {
         data <- gsub(
             "=== HOTWATER_ERROR_BEGIN ===\\s*([\\s\\S]*?)\\s*=== HOTWATER_ERROR_END ===",
-            cli::format_error(c(x = "\\1")),
+            cli::col_red("\\1"),
             data,
             perl = TRUE
         )
 
         data <- gsub(
             "=== HOTWATER_WARNING_BEGIN ===\\s*([\\s\\S]*?)\\s*=== HOTWATER_WARNING_END ===",
-            cli::format_warning(c(i = "\\1")),
+            cli::col_yellow("\\1"),
             data,
             perl = TRUE
         )

--- a/R/engine.R
+++ b/R/engine.R
@@ -65,6 +65,8 @@ buildup_engine <- function(engine) {
     stopifnot(is_engine(engine))
 
     cli_server_start_progress(engine)
+    file.create(engine$logpath)
+    engine$logpos <- 0L
     res <- new_runner(engine)
 
     if (engine$publisher$listener[[1L]][["state"]] != "started") {
@@ -87,6 +89,7 @@ teardown_engine <- function(engine) {
 
     cli_server_stop_progress()
     resp <- kill_engine(engine)
+    unlink(engine$logpath)
 
     if (isTRUE(resp)) {
         cli::cli_process_done()
@@ -125,8 +128,6 @@ drain_runner_log <- function(engine) {
     data <- readChar(con, nchars = size - logpos, useBytes = TRUE)
 
     engine$logpos <- size
-
-
 
     if (nzchar(data)) {
         data <- gsub(

--- a/R/engine.R
+++ b/R/engine.R
@@ -26,8 +26,6 @@ new_engine <- function(config) {
     )
 
     reg.finalizer(eng, function(e) {
-        try(kill_engine(e), silent=TRUE)
-        try(nanonext::close(e$publisher), silent = TRUE)
         try(unlink(e$logpath), silent = TRUE)
     }, onexit=TRUE)
 

--- a/inst/examples/plumber.R
+++ b/inst/examples/plumber.R
@@ -1,14 +1,5 @@
 #' @get /
 #' @serializer html
 function() {
-    print("got here?")
     "Hello, world!"
-    stop("oh no")
 }
-
-print('/foo')
-
-message("foo")
-
-rlang::abort("foo")
-stop('oh no')

--- a/inst/examples/plumber.R
+++ b/inst/examples/plumber.R
@@ -1,5 +1,13 @@
 #' @get /
 #' @serializer html
 function() {
+    print("got here?")
     "Hello, world!"
+    stop("oh no")
 }
+
+print('/foo')
+
+warning("bar")
+
+stop('oh no')

--- a/inst/examples/plumber.R
+++ b/inst/examples/plumber.R
@@ -8,6 +8,7 @@ function() {
 
 print('/foo')
 
-warning("bar")
+message("foo")
 
+rlang::abort("foo")
 stop('oh no')

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -29,3 +29,14 @@ test_that("can kill engine", {
     expect_false(is_runner_alive(engine))
     cleanup_test_engine(engine)
 })
+
+test_that('logs are cleared', {
+    engine <- new_test_engine()
+    new_runner(engine)
+    expect_true(file.exists(engine$logpath))
+    kill_engine(engine)
+    cleanup_test_engine(engine)
+    Sys.sleep(0.1)
+    expect_false(file.exists(engine$logpath))
+
+})

--- a/tests/testthat/test-engine.R
+++ b/tests/testthat/test-engine.R
@@ -32,11 +32,12 @@ test_that("can kill engine", {
 
 test_that('logs are cleared', {
     engine <- new_test_engine()
+    logpath <- engine$logpath
     new_runner(engine)
-    expect_true(file.exists(engine$logpath))
+    expect_true(file.exists(logpath))
     kill_engine(engine)
     cleanup_test_engine(engine)
-    Sys.sleep(0.1)
-    expect_false(file.exists(engine$logpath))
-
+    rm(engine)
+    gc()
+    expect_false(file.exists(logpath))
 })

--- a/tests/testthat/test-logging.R
+++ b/tests/testthat/test-logging.R
@@ -1,0 +1,42 @@
+# mock the nanonext fn to test if we are
+# handling the sink properly
+capture_write_stdout <- function(code) {
+    out <- character()
+    old <- nanonext::write_stdout
+    assignInNamespace(
+        "write_stdout",
+        function(x) out <<- c(out, x),
+        ns = "nanonext"
+    )
+    on.exit(assignInNamespace("write_stdout", old, ns = "nanonext"), add = TRUE)
+    code()
+    out
+}
+
+test_that('log files are created/removed', {
+    engine <- new_test_engine()
+    logpath <- engine$logpath
+    new_runner(engine)
+    expect_true(file.exists(logpath))
+    kill_engine(engine)
+    cleanup_test_engine(engine)
+    rm(engine)
+    gc()
+    expect_false(file.exists(logpath))
+})
+
+test_that("stdout drain forwards log contents", {
+  engine <- new_test_engine()
+  logpath <- engine$logpath
+
+  cat("Hello World!\n", file = logpath)
+  engine$logpos <- 0L
+
+  out <- capture_write_stdout(function() {
+    drain_runner_log(engine)
+  })
+
+  expect_true(any(grepl("Hello World!", out)))
+
+  unlink(logpath)
+})

--- a/tests/testthat/test-middleware.R
+++ b/tests/testthat/test-middleware.R
@@ -74,9 +74,17 @@ test_that("is_plumber_running works", {
 test_that("autoreloader is attached", {
     engine <- new_test_engine()
     new_runner(engine)
+
+    i <- 1L
+    while (i < 20L && !is_plumber_running(engine)) {
+        i <- i + 1L
+        Sys.sleep(0.5)
+    }
+
     resp <- sprintf("%s:%s", engine$config$host, engine$config$port) |>
         httr2::request() |>
         httr2::req_perform()
+
     expect_no_error(
         httr2::resp_check_content_type(
             resp,


### PR DESCRIPTION
Closes #8 

- Sink worker stderr/stdout into temporary file managed by hotwater
- Iteratively read and tail the file during the file watcher loop